### PR TITLE
Replace resume code with HTML/CSS

### DIFF
--- a/frontend/src/components/LivePreview.tsx
+++ b/frontend/src/components/LivePreview.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef, useImperativeHandle } from "react";
 
 type Props = {
-  code: string;
+  html: string; // React/JSX code string
   css?: string;
 };
 
 const LivePreview = React.forwardRef<HTMLIFrameElement, Props>(
-  ({ code, css = "" }, ref) => {
+  ({ html, css = "" }, ref) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
 
     useImperativeHandle(
@@ -18,7 +18,7 @@ const LivePreview = React.forwardRef<HTMLIFrameElement, Props>(
     );
 
     useEffect(() => {
-      const html = `
+      const fullHtml = `
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -51,19 +51,18 @@ const LivePreview = React.forwardRef<HTMLIFrameElement, Props>(
 
     <script type="text/babel">
       try {
-        ${code}
+        ${html}
       } catch (err) {
-        document.body.innerHTML =
-          '<pre style="color: red;">' + err + '</pre>';
+        document.body.innerHTML = '<pre style="color: red;">' + err + '</pre>';
       }
     </script>
   </body>
 </html>
 `;
       if (iframeRef.current) {
-        iframeRef.current.srcdoc = html;
+        iframeRef.current.srcdoc = fullHtml;
       }
-    }, [code, css]);
+    }, [html, css]);
 
     return (
       <iframe

--- a/frontend/src/components/ResumeEditor.tsx
+++ b/frontend/src/components/ResumeEditor.tsx
@@ -4,16 +4,17 @@ import type { Dispatch, SetStateAction } from "react";
 type Props = {
   code: string;
   setCode: Dispatch<SetStateAction<string>>;
+  language?: string;
   label?: string;
 };
 
-const ResumeEditor: React.FC<Props> = ({ code, setCode }) => {
+const ResumeEditor: React.FC<Props> = ({ code, setCode, language = "javascript" }) => {
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div style={{ flex: 1 }}>
         <Editor
           height="100%"
-          defaultLanguage="javascript"
+          defaultLanguage={language}
           value={code}
           onChange={(value) => value !== undefined && setCode(value)}
           theme="vs-dark"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,7 +5,8 @@ import axios from "axios";
 interface Resume {
   _id: string;
   name: string;
-  code: string;
+  html: string;
+  css: string;
   createdAt: string;
 }
 
@@ -71,7 +72,7 @@ const Dashboard = () => {
     const name =
       window.prompt("Enter a name for this resume", "Untitled Resume") ||
       "Untitled Resume";
-    const defaultCode = `function Resume() {
+    const defaultHtml = `function Resume() {
   return (
     <div className="resume">
       <h1>Jane Doe</h1>
@@ -81,10 +82,18 @@ const Dashboard = () => {
 }
 
 ReactDOM.render(<Resume />, document.getElementById("root"));`;
+    const defaultCss = `.resume {
+  font-family: 'Georgia', serif;
+  padding: 2rem;
+}
+.resume h1 {
+  font-size: 2rem;
+}
+`;
     try {
       const { data } = await axios.post<Resume>(
         "/api/resumes",
-        { name, code: defaultCode },
+        { name, html: defaultHtml, css: defaultCss },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setResumes((prev) => [data, ...prev]);
@@ -141,7 +150,7 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`;
                   </span>
                 </div>
                 <pre className="text-xs h-24 overflow-hidden text-gray-300">
-                  {resume.code.slice(0, 100)}...
+                  {resume.html.slice(0, 100)}...
                 </pre>
                 <div className="mt-2">
                   <button

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -12,7 +12,7 @@ const EditorPage = () => {
 
   const previewRef = useRef<HTMLIFrameElement>(null);
 
-  const [code, setCode] = useState(`function Resume() {
+  const [html, setHtml] = useState(`function Resume() {
   return (
     <div className="resume">
       <h1>Jane Doe</h1>
@@ -32,7 +32,7 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
 }
 `);
 
-  const [activeTab, setActiveTab] = useState<"jsx" | "css" | "preview">("jsx");
+  const [activeTab, setActiveTab] = useState<"html" | "css" | "preview">("html");
 
   // load existing resume
   useEffect(() => {
@@ -41,11 +41,12 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
       const token = localStorage.getItem("token");
       if (!token) return navigate("/login");
       try {
-        const { data } = await axios.get<{ code: string }>(
+        const { data } = await axios.get<{ html: string; css: string }>(
           `/api/resumes/${id}`,
           { headers: { Authorization: `Bearer ${token}` } }
         );
-        setCode(data.code);
+        setHtml(data.html);
+        setCssCode(data.css);
       } catch (err: any) {
         if (err.response?.status === 404) navigate("/dashboard");
         console.error(err);
@@ -62,7 +63,7 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
     try {
       await axios.put(
         `/api/resumes/${id}`,
-        { code },
+        { html, css: cssCode },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       // you can replace alert with a fancier toast
@@ -89,7 +90,7 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
       <div className="flex justify-between items-center bg-[#2d2d2d] px-2 text-sm select-none">
         {/* Tabs */}
         <div className="flex space-x-1">
-          {(["jsx", "css", "preview"] as const).map((tab) => (
+          {(["html", "css", "preview"] as const).map((tab) => (
             <div
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -99,8 +100,8 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
                   : "bg-[#2d2d2d] border-transparent text-gray-400 hover:text-white"
               }`}
             >
-              {tab === "jsx"
-                ? "Resume.jsx"
+              {tab === "html"
+                ? "Resume.html"
                 : tab === "css"
                 ? "Resume.css"
                 : "Preview"}
@@ -128,28 +129,28 @@ ReactDOM.render(<Resume />, document.getElementById("root"));`);
 
       {/* MOBILE: toggled view */}
       <div className="md:hidden flex-1 overflow-hidden relative">
-        <div className={activeTab === "jsx" ? "block h-full" : "hidden"}>
-          <ResumeEditor code={code} setCode={setCode} />
+        <div className={activeTab === "html" ? "block h-full" : "hidden"}>
+          <ResumeEditor code={html} setCode={setHtml} language="javascript" />
         </div>
         <div className={activeTab === "css" ? "block h-full" : "hidden"}>
-          <ResumeEditor code={cssCode} setCode={setCssCode} />
+          <ResumeEditor code={cssCode} setCode={setCssCode} language="css" />
         </div>
         <div className={activeTab === "preview" ? "block h-full" : "hidden"}>
-          <LivePreview ref={previewRef} code={code} css={cssCode} />
+          <LivePreview ref={previewRef} html={html} css={cssCode} />
         </div>
       </div>
 
       {/* DESKTOP: side-by-side */}
       <div className="hidden md:flex flex-1 border-t border-[#3c3c3c]">
         <div className="w-1/3 border-r border-[#3c3c3c]">
-          <ResumeEditor code={code} setCode={setCode} />
+          <ResumeEditor code={html} setCode={setHtml} language="javascript" />
         </div>
         <div className="w-1/3 border-r border-[#3c3c3c]">
-          <ResumeEditor code={cssCode} setCode={setCssCode} />
+          <ResumeEditor code={cssCode} setCode={setCssCode} language="css" />
         </div>
         <div className="w-1/3 bg-[#1e1e1e] flex justify-center items-center">
           <div className="w-[90%] aspect-[210/297] bg-white border shadow">
-            <LivePreview ref={previewRef} code={code} css={cssCode} />
+            <LivePreview ref={previewRef} html={html} css={cssCode} />
           </div>
         </div>
       </div>

--- a/server/model/resume.js
+++ b/server/model/resume.js
@@ -10,7 +10,11 @@ const resumeSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  code: {
+  html: {
+    type: String,
+    required: true,
+  },
+  css: {
     type: String,
     required: true,
   },

--- a/server/routes/resumeRoutes.js
+++ b/server/routes/resumeRoutes.js
@@ -7,10 +7,11 @@ const router = express.Router();
 // Create a new resume
 router.post("/", authenticate, async (req, res) => {
   try {
-    const { name, code } = req.body;
+    const { name, html, css } = req.body;
     const resume = new Resume({
       name,
-      code,
+      html,
+      css,
       user: req.user.userId,
     });
     await resume.save();
@@ -48,9 +49,15 @@ router.get("/:id", authenticate, async (req, res) => {
 // Update a resume
 router.put("/:id", authenticate, async (req, res) => {
   try {
+    const { html, css, name } = req.body;
+    const update = {};
+    if (html !== undefined) update.html = html;
+    if (css !== undefined) update.css = css;
+    if (name !== undefined) update.name = name;
+
     const resume = await Resume.findOneAndUpdate(
       { _id: req.params.id, user: req.user.userId },
-      req.body,
+      update,
       { new: true }
     );
     if (!resume)


### PR DESCRIPTION
## Summary
- update `LivePreview` to compile React code stored in `html`
- default editor languages and content expect JSX in `html`
- adjust dashboard default resume to JSX
- keep saving and loading of `html` and `css` fields

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e6e2bfa20832bbcff1a5099e72858