### PR TITLE
feat: add UI primitives and printer store

### DIFF
--- a/src/lib/components/ui/Card.svelte
+++ b/src/lib/components/ui/Card.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  export let className = '';
+</script>
+
+<div class={`card ${className}`}>
+  <slot />
+</div>
+
+<style>
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+.card:hover {
+  border-color: var(--accent);
+}
+
+.card:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+</style>

--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  export let open = false;
+  const dispatch = createEventDispatcher();
+
+  function close() {
+    dispatch('close');
+  }
+</script>
+
+{#if open}
+<div class="overlay" on:click={close}>
+  <div class="modal" on:click|stopPropagation>
+    <slot />
+  </div>
+</div>
+{/if}
+
+<style>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  min-width: 300px;
+}
+</style>

--- a/src/lib/components/ui/PanelHeader.svelte
+++ b/src/lib/components/ui/PanelHeader.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  export let title = '';
+</script>
+
+<header class="panel-header">
+  <h2>{title}</h2>
+  <div class="actions">
+    <slot />
+  </div>
+</header>
+
+<style>
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+</style>

--- a/src/lib/components/ui/Pill.svelte
+++ b/src/lib/components/ui/Pill.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  export let type: 'default' | 'accent' | 'success' | 'warning' | 'danger' = 'default';
+</script>
+
+<span class={`pill ${type}`}><slot /></span>
+
+<style>
+.pill {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  background: var(--border);
+  color: var(--text);
+}
+
+.pill.accent {
+  background: var(--accent);
+  color: var(--panel);
+}
+
+.pill.success {
+  background: var(--success);
+  color: var(--panel);
+}
+
+.pill.warning {
+  background: var(--warning);
+  color: var(--panel);
+}
+
+.pill.danger {
+  background: var(--danger);
+  color: var(--panel);
+}
+</style>

--- a/src/lib/stores/printerStore.ts
+++ b/src/lib/stores/printerStore.ts
@@ -1,0 +1,84 @@
+import { writable, derived } from 'svelte/store';
+import type { Printer, Telemetry } from '$lib/types';
+
+const initialPrinters: Printer[] = [
+  { id: 'p1', name: 'Alpha', status: 'idle', profile: 'Standard', material: 'PLA' },
+  { id: 'p2', name: 'Bravo', status: 'printing', profile: 'Fine', material: 'PETG' }
+];
+
+export const printers = writable<Printer[]>(initialPrinters);
+export const selectedId = writable<string | null>('p1');
+
+const initialTelemetry: Record<string, Telemetry> = {
+  p1: {
+    nozzleTemp: 25,
+    bedTemp: 25,
+    targetNozzle: 0,
+    targetBed: 0,
+    progress: 0,
+    stateText: 'Idle',
+    alerts: []
+  },
+  p2: {
+    nozzleTemp: 200,
+    bedTemp: 60,
+    targetNozzle: 210,
+    targetBed: 60,
+    progress: 10,
+    stateText: 'Printing',
+    alerts: []
+  }
+};
+
+export const telemetry = writable<Record<string, Telemetry>>(initialTelemetry);
+
+export const selectedPrinter = derived([
+  printers,
+  selectedId
+], ([$printers, $selectedId]) => $printers.find(p => p.id === $selectedId) || null);
+
+export const selectedTelemetry = derived([
+  telemetry,
+  selectedId
+], ([$telemetry, $selectedId]) => ($selectedId ? $telemetry[$selectedId] : null));
+
+const loops: Record<string, ReturnType<typeof setInterval>> = {};
+
+export function selectPrinter(id: string) {
+  selectedId.set(id);
+}
+
+export function startSimulation(id: string) {
+  stopSimulation(id);
+  printers.update(ps => ps.map(p => p.id === id ? { ...p, status: 'printing' } : p));
+  loops[id] = setInterval(() => {
+    telemetry.update(t => {
+      const current = t[id];
+      if (!current) return t;
+      const next: Telemetry = { ...current };
+      if (next.nozzleTemp < next.targetNozzle) {
+        next.nozzleTemp = Math.min(next.targetNozzle, next.nozzleTemp + Math.random() * 5);
+      }
+      if (next.bedTemp < next.targetBed) {
+        next.bedTemp = Math.min(next.targetBed, next.bedTemp + Math.random() * 2);
+      }
+      next.progress = Math.min(100, next.progress + Math.random() * 5);
+      if (next.progress >= 100) {
+        next.stateText = 'Completed';
+        printers.update(ps => ps.map(p => p.id === id ? { ...p, status: 'idle' } : p));
+        stopSimulation(id);
+      } else {
+        next.stateText = 'Printing';
+      }
+      return { ...t, [id]: next };
+    });
+  }, 1000);
+}
+
+export function stopSimulation(id: string) {
+  const loop = loops[id];
+  if (loop) {
+    clearInterval(loop);
+    delete loops[id];
+  }
+}

--- a/src/lib/styles/base.css
+++ b/src/lib/styles/base.css
@@ -1,0 +1,58 @@
+@import './tokens.css';
+
+:root {
+  color-scheme: dark;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+button {
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: inherit;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -1,0 +1,21 @@
+:root {
+  --bg: #0f1115;
+  --panel: #151821;
+  --text: #e6e6e6;
+  --muted: #9aa3b2;
+  --border: #242938;
+  --accent: #7aa2f7;
+  --danger: #ef4444;
+  --warning: #f59e0b;
+  --success: #22c55e;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f9fafb;
+    --panel: #ffffff;
+    --text: #0f1115;
+    --muted: #6b7280;
+    --border: #e5e7eb;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,30 @@
+export interface Printer {
+  id: string;
+  name: string;
+  status: 'idle' | 'printing' | 'error';
+  profile: string;
+  material: string;
+}
+
+export interface Telemetry {
+  nozzleTemp: number;
+  bedTemp: number;
+  targetNozzle: number;
+  targetBed: number;
+  progress: number; // 0-100
+  stateText: string;
+  alerts: string[];
+}
+
+export interface MaintenanceItem {
+  id: string;
+  title: string;
+  dueDate: string;
+  completed: boolean;
+}
+
+export interface LogLine {
+  timestamp: string;
+  message: string;
+  level?: 'info' | 'warn' | 'error';
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,6 @@
+<script>
+  import '$lib/styles/tokens.css';
+  import '$lib/styles/base.css';
+</script>
+
+<slot />


### PR DESCRIPTION
## Summary
- add theme tokens and base styles for dark/light modes
- introduce Card, PanelHeader, Pill and Modal components
- implement mock printer store with telemetry simulation and types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68aca83e8dc4832b957f4bf8e4b78aab